### PR TITLE
Add !ghauth and !ghwhois

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ typings/
 
 # database
 db.json
+gh_users.json

--- a/lib/app.js
+++ b/lib/app.js
@@ -1,6 +1,7 @@
 const fetch = require('node-fetch')
 const Discord = require('discord.js')
 const { log, sendStream } = require('./common')
+const { fetchContributors } = require('./contributors')
 const config = require('./config')
 const commands = require('./commands')
 const client = new Discord.Client()
@@ -24,6 +25,8 @@ client.on('ready', () => {
   log.info(`Logged in as ${client.user.tag}!`)
   updateStatus()
   client.setInterval(updateStatus, 60000)
+  fetchContributors()
+  client.setInterval(fetchContributors, 300000)
 })
 
 client.on('message', message => {

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -240,11 +240,7 @@ module.exports = (message, command, args) => {
           'Content-Type': 'application/json'
         }
       }).then(res => res.text())
-        .then(body => fetch(`https://api.github.com/user?${body}`, {
-          headers: {
-            Authorization: `token ${config.githubToken}`
-          }
-        }))
+        .then(body => fetch(`https://api.github.com/user?${body}`))
         .then(res => res.json())
         .then(body => {
           if (body.id) {

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -1,8 +1,10 @@
 const fetch = require('node-fetch')
 const Discord = require('discord.js')
 const config = require('./config')
-const { log, createEmbed, sendStream } = require('./common')
-const db = require('littledb')(config.databasePath)
+const { log, createEmbed, sendStream, unixSeconds } = require('./common')
+const { contributors } = require('./contributors')
+const db = require('littledb')(config.databases.commands)
+const githubUserDb = require('littledb')(config.databases.githubUsers)
 
 function canExecuteCustomCommand (message) {
   return hasPermissions(message.member) || (message.channel && !config.noCustomCommandsChannels.includes(message.channel.name))
@@ -29,10 +31,50 @@ function noPermissions (message) {
   })
 }
 
+let cooldowns = []
+
+function cooldown (user, command, seconds) {
+  if (!cooldowns[user]) {
+    cooldowns[user] = []
+  }
+  cooldowns[user][command] = unixSeconds() + seconds
+}
+
+function isOnCooldown (user, command) {
+  const userCooldowns = cooldowns[user]
+  if (!cooldowns[user]) {
+    return 0
+  }
+  const targetTime = userCooldowns[command]
+  if (!targetTime) {
+    return 0
+  }
+  const diff = targetTime - unixSeconds()
+  if (diff > 0) {
+    return diff
+  }
+  delete cooldowns[user][command]
+  if (!cooldowns[user].length) {
+    delete cooldowns[user]
+  }
+}
+
 let membersToProcess = []
 
 module.exports = (message, command, args) => {
   const value = args.join(' ')
+
+  const cooldownLeft = isOnCooldown(message.author, command)
+  if (cooldownLeft) {
+    const embed = createEmbed()
+      .setTitle('Cooldown')
+      .setDescription(`You must wait ${cooldownLeft} seconds before using that command again.`)
+    message.channel
+      .send({ embed })
+      .then(m => m.delete(Math.min(Math.max(cooldownLeft, 3), 10) * 1000)) // Delete embed after 3-10 seconds, depending on time left
+      .catch(e => log.debug(e))
+    return
+  }
 
   switch (command) {
     case 'help':
@@ -41,6 +83,8 @@ module.exports = (message, command, args) => {
         .setDescription('You can view all available commands below')
         .addField('!help', 'Display this message')
         .addField('!gh <query>', 'Search runelite/runelite GitHub for issues and pull requests')
+        .addField('!ghauth', 'DM the bot this command to link your GitHub account to the bot')
+        .addField('!ghwhois <github username>', 'Lookup the Discord name of a GitHub user who has linked their account')
 
       if (hasPermissions(message.member)) {
         helpEmbed
@@ -204,6 +248,120 @@ module.exports = (message, command, args) => {
 
       membersToProcess.forEach(m => m.ban())
       membersToProcess = []
+      break
+    }
+    case 'ghauth': {
+      message.author
+        .createDM()
+        .then(channel => {
+          if (!value) {
+            return channel.send({
+              embed: createEmbed()
+                .setTitle('GitHub account linking')
+                .setDescription(`Please visit https://github.com/login/oauth/authorize?client_id=${config.githubAuth.clientId} and follow the instructions.`)
+            })
+          } else if (value.length === 20) { // GitHub's OAuth codes are 20 characters long
+            // Prevent spamming of the GitHub API, 10s cooldown
+            cooldown(message.author, command, 10)
+
+            return fetch('https://github.com/login/oauth/access_token', {
+              method: 'POST',
+              body: JSON.stringify({
+                client_id: config.githubAuth.clientId,
+                client_secret: config.githubAuth.clientSecret,
+                code: value
+              }),
+              headers: { 'Content-Type': 'application/json' }
+            }).then(res => res.text())
+              .then(body => {
+                return fetch(`https://api.github.com/user?${body}`)
+              })
+              .then(res => res.json())
+              .then(body => {
+                let description
+
+                if (body.id) {
+                  const authedDiscordUserId = githubUserDb.get(body.id)
+
+                  // Don't allow linking a GitHub account to many Discord accounts
+                  if (authedDiscordUserId && authedDiscordUserId !== message.author.id) {
+                    description = 'Your GitHub account is already authed to a Discord user.'
+                  } else {
+                    message.client.guilds
+                      .array()
+                      .forEach(g => {
+                        g.fetchMember(message.author)
+                          .then(m => {
+                            // Add the authed role to user
+                            const role = g.roles.find(r => r.name.toLowerCase() === config.githubAuth.authedRole.toLowerCase())
+                            m.addRole(role)
+                              .catch(e => log.debug(e))
+
+                            // Add the 'contributed' role to user if they have contributed
+                            if (contributors[body.id]) {
+                              const role = g.roles.find(r => r.name.toLowerCase() === config.githubAuth.contributedRole.toLowerCase())
+                              m.addRole(role)
+                                .catch(e => log.debug(e))
+                            }
+                          }).catch(e => log.debug(e))
+                      })
+
+                    description = 'You have successfully authed your GitHub account with the bot.'
+
+                    // Save connection between GitHub user id and Discord user id
+                    githubUserDb.put(body.id, message.author.id)
+                  }
+                } else {
+                  description = 'The supplied token is invalid.'
+                }
+
+                return channel.send({
+                  embed: createEmbed()
+                    .setTitle('GitHub account linking')
+                    .setDescription(description)
+                })
+              })
+          }
+        }).catch(e => log.debug(e))
+      break
+    }
+    case 'ghwhois': {
+      if (!value || value.includes('/')) {
+        return
+      }
+
+      if (!hasPermissions(message.member)) {
+        // Prevent spamming of the GitHub API, 10s cooldown
+        cooldown(message.author, command, 10)
+      }
+
+      fetch(`https://api.github.com/users/${value}`, {
+        headers: {
+          Authorization: `token ${config.githubToken}`
+        }
+      }).then(res => res.json())
+        .then(body => {
+          let description
+
+          if (body.id) {
+            const discordId = githubUserDb.get(body.id)
+            if (discordId) {
+              description = `${value}'s Discord name is: <@${discordId}>`
+            } else {
+              description = `${value} has not connected their Discord account.`
+            }
+          } else {
+            description = `${value} is not a registered GitHub user.`
+          }
+
+          return message.channel.send({
+            embed: createEmbed()
+              .setTitle('GitHub Whois')
+              .setDescription(description)
+          })
+        })
+        .catch(e => log.debug(e))
+
       break
     }
     default: {

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -1,7 +1,7 @@
 const fetch = require('node-fetch')
 const Discord = require('discord.js')
 const config = require('./config')
-const { log, createEmbed, sendStream, unixSeconds } = require('./common')
+const { log, createEmbed, sendStream, sendDM } = require('./common')
 const { contributors } = require('./contributors')
 const db = require('littledb')(config.databases.commands)
 const githubUserDb = require('littledb')(config.databases.githubUsers)
@@ -31,50 +31,10 @@ function noPermissions (message) {
   })
 }
 
-let cooldowns = []
-
-function cooldown (user, command, seconds) {
-  if (!cooldowns[user]) {
-    cooldowns[user] = []
-  }
-  cooldowns[user][command] = unixSeconds() + seconds
-}
-
-function isOnCooldown (user, command) {
-  const userCooldowns = cooldowns[user]
-  if (!cooldowns[user]) {
-    return 0
-  }
-  const targetTime = userCooldowns[command]
-  if (!targetTime) {
-    return 0
-  }
-  const diff = targetTime - unixSeconds()
-  if (diff > 0) {
-    return diff
-  }
-  delete cooldowns[user][command]
-  if (!cooldowns[user].length) {
-    delete cooldowns[user]
-  }
-}
-
 let membersToProcess = []
 
 module.exports = (message, command, args) => {
   const value = args.join(' ')
-
-  const cooldownLeft = isOnCooldown(message.author, command)
-  if (cooldownLeft) {
-    const embed = createEmbed()
-      .setTitle('Cooldown')
-      .setDescription(`You must wait ${cooldownLeft} seconds before using that command again.`)
-    message.channel
-      .send({ embed })
-      .then(m => m.delete(Math.min(Math.max(cooldownLeft, 3), 10) * 1000)) // Delete embed after 3-10 seconds, depending on time left
-      .catch(e => log.debug(e))
-    return
-  }
 
   switch (command) {
     case 'help':
@@ -251,88 +211,92 @@ module.exports = (message, command, args) => {
       break
     }
     case 'ghauth': {
-      message.author
-        .createDM()
-        .then(channel => {
-          if (!value) {
-            return channel.send({
-              embed: createEmbed()
-                .setTitle('GitHub account linking')
-                .setDescription(`Please visit https://github.com/login/oauth/authorize?client_id=${config.githubAuth.clientId} and follow the instructions.`)
-            })
-          } else if (value.length === 20) { // GitHub's OAuth codes are 20 characters long
-            // Prevent spamming of the GitHub API, 10s cooldown
-            cooldown(message.author, command, 10)
-
-            return fetch('https://github.com/login/oauth/access_token', {
-              method: 'POST',
-              body: JSON.stringify({
-                client_id: config.githubAuth.clientId,
-                client_secret: config.githubAuth.clientSecret,
-                code: value
-              }),
-              headers: { 'Content-Type': 'application/json' }
-            }).then(res => res.text())
-              .then(body => {
-                return fetch(`https://api.github.com/user?${body}`)
-              })
-              .then(res => res.json())
-              .then(body => {
-                let description
-
-                if (body.id) {
-                  const authedDiscordUserId = githubUserDb.get(body.id)
-
-                  // Don't allow linking a GitHub account to many Discord accounts
-                  if (authedDiscordUserId && authedDiscordUserId !== message.author.id) {
-                    description = 'Your GitHub account is already authed to a Discord user.'
-                  } else {
-                    message.client.guilds
-                      .array()
-                      .forEach(g => {
-                        g.fetchMember(message.author)
-                          .then(m => {
-                            // Add the authed role to user
-                            const role = g.roles.find(r => r.name.toLowerCase() === config.githubAuth.authedRole.toLowerCase())
-                            m.addRole(role)
-                              .catch(e => log.debug(e))
-
-                            // Add the 'contributed' role to user if they have contributed
-                            if (contributors[body.id]) {
-                              const role = g.roles.find(r => r.name.toLowerCase() === config.githubAuth.contributedRole.toLowerCase())
-                              m.addRole(role)
-                                .catch(e => log.debug(e))
-                            }
-                          }).catch(e => log.debug(e))
-                      })
-
-                    description = 'You have successfully authed your GitHub account with the bot.'
-
-                    // Save connection between GitHub user id and Discord user id
-                    githubUserDb.put(body.id, message.author.id)
-                  }
-                } else {
-                  description = 'The supplied token is invalid.'
-                }
-
-                return channel.send({
-                  embed: createEmbed()
-                    .setTitle('GitHub account linking')
-                    .setDescription(description)
-                })
-              })
-          }
-        }).catch(e => log.debug(e))
-      break
-    }
-    case 'ghwhois': {
-      if (!value || value.includes('/')) {
-        return
+      if (!value) {
+        return sendDM(message.author, {
+          embed: createEmbed()
+            .setTitle('GitHub account linking')
+            .setDescription(`Please visit https://github.com/login/oauth/authorize?client_id=${config.githubAuth.clientId} and follow the instructions.`)
+        })
       }
 
-      if (!hasPermissions(message.member)) {
-        // Prevent spamming of the GitHub API, 10s cooldown
-        cooldown(message.author, command, 10)
+      // GitHub's OAuth codes are 20 characters long
+      if (value.length !== 20) {
+        return sendDM(message.author, {
+          embed: createEmbed()
+            .setTitle('GitHub account linking')
+            .setDescription('The supplied token is invalid.')
+            .setColor(0xFF0000)
+        })
+      }
+
+      return fetch('https://github.com/login/oauth/access_token', {
+        method: 'POST',
+        body: JSON.stringify({
+          client_id: config.githubAuth.clientId,
+          client_secret: config.githubAuth.clientSecret,
+          code: value
+        }),
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      }).then(res => res.text())
+        .then(body => fetch(`https://api.github.com/user?${body}`, {
+          headers: {
+            Authorization: `token ${config.githubToken}`
+          }
+        }))
+        .then(res => res.json())
+        .then(body => {
+          if (body.id) {
+            const authedDiscordUserId = githubUserDb.get(body.id)
+
+            // Don't allow linking a GitHub account to many Discord accounts
+            if (authedDiscordUserId && authedDiscordUserId !== message.author.id) {
+              return sendDM(message.author, {
+                embed: createEmbed()
+                  .setTitle('GitHub account linking')
+                  .setDescription('Your GitHub account is already linked to a Discord user.')
+                  .setColor(0xFF0000)
+              })
+            }
+
+            message.client.guilds.forEach(g => g
+              .fetchMember(message.author)
+              .then(m => {
+                // Add the authed role to user
+                const role = g.roles.find(r => r.name.toLowerCase() === config.githubAuth.authedRole.toLowerCase())
+                m.addRole(role).catch(e => log.debug(e))
+
+                // Add the 'contributed' role to user if they have contributed
+                if (contributors[body.id]) {
+                  const role = g.roles.find(r => r.name.toLowerCase() === config.githubAuth.contributedRole.toLowerCase())
+                  m.addRole(role).catch(e => log.debug(e))
+                }
+              })
+              .catch(e => log.debug(e)))
+
+            // Save connection between GitHub user id and Discord user id
+            githubUserDb.put(body.id, message.author.id)
+
+            return sendDM(message.author, {
+              embed: createEmbed()
+                .setTitle('GitHub account linking')
+                .setDescription('You have successfully linked your GitHub account with the bot.')
+                .setColor(0x00FF00)
+            })
+          }
+
+          return sendDM(message.author, {
+            embed: createEmbed()
+              .setTitle('GitHub account linking')
+              .setDescription('The supplied token expired.')
+              .setColor(0xFF0000)
+          })
+        })
+    }
+    case 'ghwhois': {
+      if (!value) {
+        return
       }
 
       fetch(`https://api.github.com/users/${value}`, {

--- a/lib/common.js
+++ b/lib/common.js
@@ -46,13 +46,13 @@ function sendStream (channel, member, streamerId) {
       }))
 }
 
-function unixSeconds () {
-  return Math.floor(new Date() / 1000)
+function sendDM (author, message) {
+  return author.createDM().then(channel => channel.send(message))
 }
 
 module.exports = {
   log,
   createEmbed,
   sendStream,
-  unixSeconds
+  sendDM
 }

--- a/lib/common.js
+++ b/lib/common.js
@@ -46,8 +46,13 @@ function sendStream (channel, member, streamerId) {
       }))
 }
 
+function unixSeconds () {
+  return Math.floor(new Date() / 1000)
+}
+
 module.exports = {
   log,
   createEmbed,
-  sendStream
+  sendStream,
+  unixSeconds
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -27,7 +27,7 @@ module.exports = {
   githubAuth: {
     clientId: process.env.GITHUB_AUTH_CLIENT_ID,
     clientSecret: process.env.GITHUB_AUTH_CLIENT_SECRET,
-    authedRole: 'github-authed',
-    contributedRole: 'github-contributed'
+    authedRole: 'github-verified',
+    contributedRole: 'github-contributor'
   }
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -3,8 +3,12 @@ module.exports = {
   logLevel: process.env.LOG_LEVEL || 'info',
   // Bot command prefix in Discord server
   prefix: '!',
-  // Path to database holding custom commands
-  databasePath: './db.json',
+  databases: {
+    // Path to database holding custom commands
+    commands: './db.json',
+    // Path to database holding links between GitHub user id and Discord user id
+    githubUsers: './gh_users.json'
+  },
   // Name of Discord role that will be used to check if user can be announced
   streamerRole: 'streamer',
   // Name of Discord channel where streamers will be announced
@@ -18,5 +22,12 @@ module.exports = {
   // This is token used for bot to login, must be from Discord Application who has bot enabled
   discordToken: process.env.DISCORD_TOKEN,
   // Used for getting information about streamer from Twitch API
-  twitchClientId: process.env.TWITCH_CLIENT_ID
+  twitchClientId: process.env.TWITCH_CLIENT_ID,
+  // Used for connecting Discord and GitHub accounts
+  githubAuth: {
+    clientId: process.env.GITHUB_AUTH_CLIENT_ID,
+    clientSecret: process.env.GITHUB_AUTH_CLIENT_SECRET,
+    authedRole: 'github-authed',
+    contributedRole: 'github-contributed'
+  }
 }

--- a/lib/contributors.js
+++ b/lib/contributors.js
@@ -1,0 +1,32 @@
+const { log } = require('./common')
+const fetch = require('node-fetch')
+const config = require('./config')
+
+let lastContributorPage = 0
+let contributors = []
+
+function fetchContributors () {
+  fetch(`https://api.github.com/repos/runelite/runelite/contributors?per_page=100&page=${lastContributorPage}&anon=true`, {
+    headers: {
+      Authorization: `token ${config.githubToken}`
+    }
+  }).then(res => res.json())
+    .then(body => {
+      body.forEach(c => {
+        if (c.id) {
+          contributors[c.id] = c.login
+        }
+      })
+
+      if (body.length === 100) {
+        lastContributorPage++
+        fetchContributors()
+      }
+    })
+    .catch(e => log.debug(e))
+}
+
+module.exports = {
+  fetchContributors,
+  contributors
+}


### PR DESCRIPTION
Adds the ability to link Discord users with their GitHub accounts.

The user types !ghauth, receives the GitHub OAuth link, presses the link and authenticates, gets redirected to https://runelite.net/gh-auth-code?code=..... (https://github.com/runelite/runelite.net/pull/176), which tells the user to send the code to the bot by "!ghauth code".

The bot then tries the code and sees who the code belongs to, to link the accounts. One GitHub account can only be linked to one Discord account.

Please discuss whether this is an acceptable solution.

If user has made a contribution to runelite/runelite, they receive the github-contributed and github-authed ranks, otherwise they only get the github-authed rank.

The connection is saved in a database file so that looking up the Discord name of a GitHub user is available by !ghwhois.