### PR TITLE
Change permission error to Direct Message w updated information

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -20,15 +20,18 @@ function hasAdminPermissions (member) {
 
 function noPermissions (message) {
   const errorMessage = message.member
-    ? 'You do not have enough permissions to run this command'
-    : 'You need to be in guild channel for this command to work'
+    ? 'You can\'t run this command'
+    : 'You need to be in a guild channel for this command to work'
 
-  return message.channel.send({
+  const place = message.channel && message.member ? ' inside ' + message.channel : ''
+
+  return sendDM(message.author, {
     embed: createEmbed()
       .setTitle('Failed to execute command')
-      .setDescription(errorMessage)
+      .setDescription(errorMessage + place)
+      .addField('Command', message.content)
       .setColor(0xFF0000)
-  })
+  }).catch(() => message.channel.send(errorMessage + ' here'))
 }
 
 let membersToProcess = []

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -363,15 +363,17 @@ module.exports = (message, command, args) => {
       break
     }
     default: {
+      const value = db.get(command)
+
+      if (!value) {
+        return
+      }
+
       if (!canExecuteCustomCommand(message)) {
         return noPermissions(message)
       }
 
-      const value = db.get(command)
-
-      if (value) {
-        message.channel.send(value)
-      }
+      message.channel.send(value)
     }
   }
 }


### PR DESCRIPTION
Also fixes an issue where the bot responds to invalid commands

### Updated error information 
#### Direct Message
![https://i.imgur.com/a6nUbE3.png](https://i.imgur.com/a6nUbE3.png)
Upon successfully sending this DM the triggering message will be deleted from the chat

~~Since all custom commands can be ran via DMing the bot the results of the the command have been added to the message. This is to prevent the user from having to resend the same command again as a DM.~~

#### Channel Message (fallback)
![https://i.imgur.com/W2XSlFi.png](https://i.imgur.com/W2XSlFi.png)
This is only sent if the DM fails.