### PR TITLE
Check if members on mentions exist

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -298,7 +298,8 @@ module.exports = (message, command, args) => {
         return
       }
 
-      const mention = message.mentions.members.first()
+      const members = message.mentions.members
+      const mention = members && members.first()
 
       if (mention) {
         let ghId


### PR DESCRIPTION
In DMs this array is null instead of being empty and so this will crash
the bot.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>