### PR TITLE
Add bot PR/Issue comment support for custom commands

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -7,6 +7,8 @@ const db = require('littledb')(config.databases.commands)
 const githubUserDb = require('littledb')(config.databases.githubUsers)
 
 const numberMatcher = new RegExp('^\\d+$')
+// Block duplicate commands for this many seconds
+const commandTimeout = 10
 
 function canExecuteCustomCommand (message) {
   return hasPermissions(message.member) || (message.channel && !config.noCustomCommandsChannels.includes(message.channel.name))
@@ -71,6 +73,7 @@ function addCommentToGithubIssue (id, message) {
 }
 
 let membersToProcess = []
+let commandsRan = []
 
 module.exports = (message, command, args) => {
   const value = args.join(' ')
@@ -431,6 +434,16 @@ module.exports = (message, command, args) => {
       if (!hasAdminPermissions(message.member)) {
         return noPermissions(message)
       }
+
+      const date = new Date()
+      date.setSeconds(date.getSeconds() - commandTimeout)
+      commandsRan = commandsRan.filter(c => c.date >= date)
+
+      if (commandsRan.find(c => c.id === id && c.cmd === cmd)) {
+        return
+      }
+
+      commandsRan.push({ id, cmd, date: new Date() })
 
       return addCommentToGithubIssue(id, value)
     }

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -6,6 +6,8 @@ const { contributors } = require('./contributors')
 const db = require('littledb')(config.databases.commands)
 const githubUserDb = require('littledb')(config.databases.githubUsers)
 
+const numberMatcher = new RegExp('^\\d+$')
+
 function canExecuteCustomCommand (message) {
   return hasPermissions(message.member) || (message.channel && !config.noCustomCommandsChannels.includes(message.channel.name))
 }
@@ -34,6 +36,40 @@ function noPermissions (message) {
   }).catch(() => message.channel.send(errorMessage + ' here'))
 }
 
+function searchMainGithubIssues (value) {
+  return fetch(`https://api.github.com/search/issues?q=repo:runelite/runelite+${value}`, {
+    headers: {
+      Authorization: `token ${config.githubToken}`
+    }
+  }).then(res => res.json())
+}
+
+function addCommentToGithubIssue (id, message) {
+  searchMainGithubIssues(id).then(body => {
+    if (body.items.length === 0) {
+      return
+    }
+
+    const commentsURL = body.items[0].comments_url
+
+    if (!commentsURL) {
+      return
+    }
+
+    return fetch(commentsURL, {
+      method: 'POST',
+      headers: {
+        'Authorization': `token ${config.githubToken}`,
+        'User-Agent': 'RuneLite-Bot',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        body: message
+      })
+    }).catch(e => log.debug(e))
+  })
+}
+
 let membersToProcess = []
 
 module.exports = (message, command, args) => {
@@ -56,6 +92,15 @@ module.exports = (message, command, args) => {
           .addField('!stream <streamer>', 'Display preview for streamer')
       }
 
+      if (hasAdminPermissions(message.member)) {
+        helpEmbed
+          .addField('!procadd <name_regex>', 'Adds members matching names to multi-processing queue')
+          .addField('!procdel', 'Clears multi-processing queue')
+          .addField('!prockick', 'Kicks everyone in multi-processing queue')
+          .addField('!procban', 'Bans everyone in multi-processing queue')
+          .addField('!ghmsg <issue> <command>', 'Adds the command output as a comment to the issue id')
+      }
+
       if (canExecuteCustomCommand(message)) {
         helpEmbed.addField('Custom commands', '!' + db.ls().sort().join('\n!'))
       }
@@ -66,27 +111,25 @@ module.exports = (message, command, args) => {
 
       break
     case 'gh':
-      fetch(`https://api.github.com/search/issues?q=repo:runelite/runelite+${value}`, {
-        headers: {
-          Authorization: `token ${config.githubToken}`
+      searchMainGithubIssues(value).then(body => {
+        if (body.items.length === 0) {
+          return
         }
-      })
-        .then(res => res.json())
-        .then(body => {
-          const item = body.items[0]
-          const description = item.body.length < 500
-            ? item.body
-            : item.body.substring(0, 500) + '...'
 
-          const embed = createEmbed()
-            .setTitle(`#${item.number} ${item.title}`)
-            .setAuthor(item.user.login)
-            .setURL(item.html_url)
-            .setDescription(description)
-            .setThumbnail(item.user.avatar_url)
+        const item = body.items[0]
+        const description = item.body.length < 500
+          ? item.body
+          : item.body.substring(0, 500) + '...'
 
-          return message.channel.send({ embed })
-        }).catch(e => log.debug(e))
+        const embed = createEmbed()
+          .setTitle(`#${item.number} ${item.title}`)
+          .setAuthor(item.user.login)
+          .setURL(item.html_url)
+          .setDescription(description)
+          .setThumbnail(item.user.avatar_url)
+
+        return message.channel.send({ embed })
+      }).catch(e => log.debug(e))
 
       break
     case 'add':
@@ -365,6 +408,31 @@ module.exports = (message, command, args) => {
         .catch(e => log.debug(e))
 
       break
+    }
+    case 'ghmsg': {
+      if (args.length < 2) {
+        return
+      }
+
+      const id = args[0]
+      const cmd = args[1]
+
+      // ID must be a number
+      if (!id.match(numberMatcher)) {
+        return
+      }
+
+      const value = db.get(cmd)
+      // Only works with custom commands
+      if (!value) {
+        return
+      }
+
+      if (!hasAdminPermissions(message.member)) {
+        return noPermissions(message)
+      }
+
+      return addCommentToGithubIssue(id, value)
     }
     default: {
       const value = db.get(command)


### PR DESCRIPTION
Adds PR/Issue commenting support to the bot. Requires admin permissions and only supports other custom commands.

### New command format:
`!ghmsg <issue> <command>`
I.E.
`!ghmsg 7000 rejected`

This will take the output of `<command>` and add it as a comment to the PR/Issue, `<issue>`. Must specify the issue ID