### PR TITLE
Automatically apply github-contributor role on fetch

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -6,7 +6,6 @@ const config = require('./config')
 const commands = require('./commands')
 const client = new Discord.Client()
 const streamerMessages = new Map()
-const githubUserDb = require('littledb')(config.databases.githubUsers)
 
 function updateStatus () {
   fetch('https://api.github.com/repos/runelite/runelite/tags', {
@@ -26,8 +25,8 @@ client.on('ready', () => {
   log.info(`Logged in as ${client.user.tag}!`)
   updateStatus()
   client.setInterval(updateStatus, 60000)
-  fetchContributors(githubUserDb, client.guilds)
-  client.setInterval(() => fetchContributors(githubUserDb, client.guilds), 300000)
+  fetchContributors(client.guilds)
+  client.setInterval(() => fetchContributors(client.guilds), 300000)
 })
 
 client.on('message', message => {
@@ -42,7 +41,7 @@ client.on('message', message => {
   const args = message.content.slice(config.prefix.length).trim().split(/ +/g)
   const command = args.shift().toLowerCase()
   log.debug('Received command', command, args)
-  commands(message, command, args, githubUserDb)
+  commands(message, command, args)
 })
 
 client.on('presenceUpdate', (oldMember, newMember) => {

--- a/lib/app.js
+++ b/lib/app.js
@@ -6,6 +6,7 @@ const config = require('./config')
 const commands = require('./commands')
 const client = new Discord.Client()
 const streamerMessages = new Map()
+const githubUserDb = require('littledb')(config.databases.githubUsers)
 
 function updateStatus () {
   fetch('https://api.github.com/repos/runelite/runelite/tags', {
@@ -25,8 +26,8 @@ client.on('ready', () => {
   log.info(`Logged in as ${client.user.tag}!`)
   updateStatus()
   client.setInterval(updateStatus, 60000)
-  fetchContributors()
-  client.setInterval(fetchContributors, 300000)
+  fetchContributors(githubUserDb, client.guilds)
+  client.setInterval(() => fetchContributors(githubUserDb, client.guilds), 300000)
 })
 
 client.on('message', message => {
@@ -41,7 +42,7 @@ client.on('message', message => {
   const args = message.content.slice(config.prefix.length).trim().split(/ +/g)
   const command = args.shift().toLowerCase()
   log.debug('Received command', command, args)
-  commands(message, command, args)
+  commands(message, command, args, githubUserDb)
 })
 
 client.on('presenceUpdate', (oldMember, newMember) => {

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -1,7 +1,7 @@
 const fetch = require('node-fetch')
 const Discord = require('discord.js')
 const config = require('./config')
-const { log, createEmbed, sendStream, sendDM } = require('./common')
+const { log, createEmbed, sendStream, sendDM, githubUserDb } = require('./common')
 const { contributors } = require('./contributors')
 const db = require('littledb')(config.databases.commands)
 
@@ -35,7 +35,7 @@ function noPermissions (message) {
 
 let membersToProcess = []
 
-module.exports = (message, command, args, githubUserDb) => {
+module.exports = (message, command, args) => {
   const value = args.join(' ')
 
   switch (command) {

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -4,7 +4,6 @@ const config = require('./config')
 const { log, createEmbed, sendStream, sendDM } = require('./common')
 const { contributors } = require('./contributors')
 const db = require('littledb')(config.databases.commands)
-const githubUserDb = require('littledb')(config.databases.githubUsers)
 
 function canExecuteCustomCommand (message) {
   return hasPermissions(message.member) || (message.channel && !config.noCustomCommandsChannels.includes(message.channel.name))
@@ -36,7 +35,7 @@ function noPermissions (message) {
 
 let membersToProcess = []
 
-module.exports = (message, command, args) => {
+module.exports = (message, command, args, githubUserDb) => {
   const value = args.join(' ')
 
   switch (command) {

--- a/lib/common.js
+++ b/lib/common.js
@@ -2,6 +2,7 @@ const fetch = require('node-fetch')
 const { RichEmbed } = require('discord.js')
 const log = require('loglevel')
 const config = require('./config')
+const githubUserDb = require('littledb')(config.databases.githubUsers)
 log.setLevel(config.logLevel)
 
 function createEmbed () {
@@ -54,5 +55,6 @@ module.exports = {
   log,
   createEmbed,
   sendStream,
-  sendDM
+  sendDM,
+  githubUserDb
 }

--- a/lib/contributors.js
+++ b/lib/contributors.js
@@ -5,7 +5,7 @@ const config = require('./config')
 let lastContributorPage = 0
 let contributors = []
 
-function fetchContributors () {
+function fetchContributors (db, guilds) {
   fetch(`https://api.github.com/repos/runelite/runelite/contributors?per_page=100&page=${lastContributorPage}&anon=true`, {
     headers: {
       Authorization: `token ${config.githubToken}`
@@ -15,15 +15,38 @@ function fetchContributors () {
       body.forEach(c => {
         if (c.id) {
           contributors[c.id] = c.login
+
+          // Ensure player has the contributor role
+          ensureContributorRole(db, guilds, c.id)
         }
       })
 
       if (body.length === 100) {
         lastContributorPage++
-        fetchContributors()
+        fetchContributors(db, guilds)
       }
     })
     .catch(e => log.debug(e))
+}
+
+function ensureContributorRole (githubUserDb, guilds, githubID) {
+  const authedDiscordUserId = githubUserDb.get(githubID)
+  if (!authedDiscordUserId) {
+    return
+  }
+
+  guilds.forEach(g => {
+    const m = g.members.get(authedDiscordUserId)
+    if (m) {
+      const roleName = config.githubAuth.contributedRole.toLowerCase()
+      const foundRole = m.roles.find(r => r.name.toLowerCase() === roleName)
+
+      if (!foundRole) {
+        const role = g.roles.find(r => r.name.toLowerCase() === roleName)
+        m.addRole(role).catch(e => log.debug(e))
+      }
+    }
+  })
 }
 
 module.exports = {

--- a/lib/contributors.js
+++ b/lib/contributors.js
@@ -1,11 +1,11 @@
-const { log } = require('./common')
+const { log, githubUserDb } = require('./common')
 const fetch = require('node-fetch')
 const config = require('./config')
 
 let lastContributorPage = 0
 let contributors = []
 
-function fetchContributors (db, guilds) {
+function fetchContributors (guilds) {
   fetch(`https://api.github.com/repos/runelite/runelite/contributors?per_page=100&page=${lastContributorPage}&anon=true`, {
     headers: {
       Authorization: `token ${config.githubToken}`
@@ -17,19 +17,19 @@ function fetchContributors (db, guilds) {
           contributors[c.id] = c.login
 
           // Ensure player has the contributor role
-          ensureContributorRole(db, guilds, c.id)
+          ensureContributorRole(guilds, c.id)
         }
       })
 
       if (body.length === 100) {
         lastContributorPage++
-        fetchContributors(db, guilds)
+        fetchContributors(guilds)
       }
     })
     .catch(e => log.debug(e))
 }
 
-function ensureContributorRole (githubUserDb, guilds, githubID) {
+function ensureContributorRole (guilds, githubID) {
   const authedDiscordUserId = githubUserDb.get(githubID)
   if (!authedDiscordUserId) {
     return


### PR DESCRIPTION
Currently if someone is `github-verified` and contributes to the repository the bot doesn't add their `github-contributor` role.  This fixes that by checking each contributor to ensure they have the role on fetch.