### PR TITLE
Limit to 7 lines of text in embedded !gh messages

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -74,9 +74,16 @@ module.exports = (message, command, args) => {
         .then(res => res.json())
         .then(body => {
           const item = body.items[0]
-          const description = item.body.length < 500
-            ? item.body
-            : item.body.substring(0, 500) + '...'
+          let description = item.body.substring(0, 500)
+
+          const lines = description.split('\n')
+          if (lines.length > 7) {
+            description = lines.splice(0, 7).join('\n')
+          }
+
+          if (description !== item.body) {
+            description += '...'
+          }
 
           const embed = createEmbed()
             .setTitle(`#${item.number} ${item.title}`)


### PR DESCRIPTION
Limits long embedded messages that are under the 500 character limit to the first 7 lines.

Before:
![https://i.imgur.com/EjCqtbW.png](https://i.imgur.com/EjCqtbW.png)

After:
![https://i.imgur.com/utzL6IK.png](https://i.imgur.com/utzL6IK.png)