### PR TITLE
Increase timeouts for periodic fetching and remove gh calls

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -9,14 +9,7 @@ const client = new Discord.Client()
 const streamerMessages = new Map()
 
 function updateStatus () {
-  return fetch('https://api.github.com/repos/runelite/runelite/tags', {
-    headers: {
-      Authorization: `token ${config.githubToken}`
-    }
-  }).then(res => res.json())
-    .then(body => {
-      return fetch(`https://api.runelite.net/session/count`)
-    })
+  return fetch(`https://api.runelite.net/session/count`)
     .then(res => res.json())
     .then(body => client.user.setActivity(`${body} players online`))
     .catch(e => log.debug(e))
@@ -47,7 +40,7 @@ function scheduleWithFixedDelay (client, promiseCreator, delay) {
 client.on('ready', () => {
   log.info(`Logged in as ${client.user.tag}!`)
   scheduleWithFixedDelay(client, updateStatus, 60000)
-  scheduleWithFixedDelay(client, () => fetchAllContributors(client), 300000)
+  scheduleWithFixedDelay(client, () => fetchAllContributors(client), 30 * 60000)
 })
 
 client.on('message', message => {


### PR DESCRIPTION
- Change contributor updates to run every 30 minutes
- Change status updates to not use github api for no reason

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>