### PR TITLE
Remove contributor roles from users blocked from the organization

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -17,7 +17,7 @@ function updateStatus () {
 }
 
 function fetchAllContributors (client) {
-  var contributorPromise = null
+  let contributorPromise = null
 
   for (let contributorRepo of config.contributorRepos) {
     const contrCallback = () => fetchContributors(contributorRepo, client.guilds, 0)

--- a/lib/app.js
+++ b/lib/app.js
@@ -2,6 +2,7 @@ const fetch = require('node-fetch')
 const Discord = require('discord.js')
 const { log, sendStream } = require('./common')
 const { fetchContributors } = require('./contributors')
+const { fetchBlocked } = require('./blocked')
 const config = require('./config')
 const commands = require('./commands')
 const filter = require('./filter')
@@ -41,6 +42,7 @@ client.on('ready', () => {
   log.info(`Logged in as ${client.user.tag}!`)
   scheduleWithFixedDelay(client, updateStatus, 60000)
   scheduleWithFixedDelay(client, () => fetchAllContributors(client), 30 * 60000)
+  scheduleWithFixedDelay(client, () => fetchBlocked(client.guilds), 60 * 60000)
 })
 
 client.on('message', message => {

--- a/lib/blocked.js
+++ b/lib/blocked.js
@@ -1,0 +1,55 @@
+const { log, githubUserDb } = require('./common')
+const fetch = require('node-fetch')
+const config = require('./config')
+
+let blocked = []
+
+function fetchBlocked (guilds) {
+  log.debug(`Fetching users blocked from the ${config.github.organization} organization`)
+
+  return fetch(`https://api.github.com/orgs/${config.github.organization}/blocks`, {
+    headers: {
+      Authorization: `token ${config.githubToken}`,
+      // We need a custom header because the api endpoint for blocked users is only available for preview
+      Accept: `application/vnd.github.giant-sentry-fist-preview+json`
+    }
+  }).then(res => res.json())
+    .then(body => {
+      log.debug(`Fetched ${body.length} blocked users`)
+      body.forEach(c => {
+        if (c.id) {
+          blocked[c.id] = c.login
+
+          // Ensure account have ghauth at the most
+          ensureBlockedFromOrganization(guilds, c.id)
+        }
+      })
+    })
+    .catch(e => log.debug(e))
+}
+
+function ensureBlockedFromOrganization (guilds, githubID) {
+  const authedDiscordUserId = githubUserDb.get(githubID)
+  if (!authedDiscordUserId) {
+    return
+  }
+
+  guilds.forEach(g => {
+    const m = g.members.get(authedDiscordUserId)
+    if (m) {
+      const roleName = config.github.contributedRole.toLowerCase()
+      const foundRole = m.roles.find(r => r.name.toLowerCase() === roleName)
+
+      if (foundRole) {
+        log.debug(`Removing contributor role from blocked user ${m.name}`)
+        const role = g.roles.find(r => r.name.toLowerCase() === roleName)
+        m.removeRole(role).catch(e => log.debug(e))
+      }
+    }
+  })
+}
+
+module.exports = {
+  fetchBlocked,
+  blocked
+}

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -197,7 +197,7 @@ module.exports = (message, command, args) => {
         return sendDM(message.author, {
           embed: createEmbed()
             .setTitle('GitHub account linking')
-            .setDescription(`Please visit https://github.com/login/oauth/authorize?client_id=${config.githubAuth.clientId} and follow the instructions.`)
+            .setDescription(`Please visit https://github.com/login/oauth/authorize?client_id=${config.github.clientId} and follow the instructions.`)
         })
       }
 
@@ -214,8 +214,8 @@ module.exports = (message, command, args) => {
       return fetch('https://github.com/login/oauth/access_token', {
         method: 'POST',
         body: JSON.stringify({
-          client_id: config.githubAuth.clientId,
-          client_secret: config.githubAuth.clientSecret,
+          client_id: config.github.clientId,
+          client_secret: config.github.clientSecret,
           code: value
         }),
         headers: {
@@ -242,12 +242,12 @@ module.exports = (message, command, args) => {
               .fetchMember(message.author)
               .then(m => {
                 // Add the authed role to user
-                const role = g.roles.find(r => r.name.toLowerCase() === config.githubAuth.authedRole.toLowerCase())
+                const role = g.roles.find(r => r.name.toLowerCase() === config.github.authedRole.toLowerCase())
                 m.addRole(role).catch(e => log.debug(e))
 
                 // Add the 'contributed' role to user if they have contributed
                 if (contributors[body.id]) {
-                  const role = g.roles.find(r => r.name.toLowerCase() === config.githubAuth.contributedRole.toLowerCase())
+                  const role = g.roles.find(r => r.name.toLowerCase() === config.github.contributedRole.toLowerCase())
                   m.addRole(role).catch(e => log.debug(e))
                 }
               })

--- a/lib/config.js
+++ b/lib/config.js
@@ -24,7 +24,7 @@ module.exports = {
   // Used for getting information about streamer from Twitch API
   twitchClientId: process.env.TWITCH_CLIENT_ID,
   // Used for connecting Discord and GitHub accounts
-  githubAuth: {
+  github: {
     clientId: process.env.GITHUB_AUTH_CLIENT_ID,
     clientSecret: process.env.GITHUB_AUTH_CLIENT_SECRET,
     authedRole: 'github-verified',

--- a/lib/config.js
+++ b/lib/config.js
@@ -28,7 +28,8 @@ module.exports = {
     clientId: process.env.GITHUB_AUTH_CLIENT_ID,
     clientSecret: process.env.GITHUB_AUTH_CLIENT_SECRET,
     authedRole: 'github-verified',
-    contributedRole: 'github-contributor'
+    contributedRole: 'github-contributor',
+    organization: 'runelite'
   },
   // GitHub repositories to fetch contributors from
   contributorRepos: [

--- a/lib/contributors.js
+++ b/lib/contributors.js
@@ -39,7 +39,7 @@ function ensureContributorRole (guilds, githubID) {
   guilds.forEach(g => {
     const m = g.members.get(authedDiscordUserId)
     if (m) {
-      const roleName = config.githubAuth.contributedRole.toLowerCase()
+      const roleName = config.github.contributedRole.toLowerCase()
       const foundRole = m.roles.find(r => r.name.toLowerCase() === roleName)
 
       if (!foundRole) {

--- a/lib/contributors.js
+++ b/lib/contributors.js
@@ -1,6 +1,7 @@
 const { log, githubUserDb } = require('./common')
 const fetch = require('node-fetch')
 const config = require('./config')
+const blocked = require('./blocked')
 
 let contributors = []
 
@@ -42,7 +43,7 @@ function ensureContributorRole (guilds, githubID) {
       const roleName = config.github.contributedRole.toLowerCase()
       const foundRole = m.roles.find(r => r.name.toLowerCase() === roleName)
 
-      if (!foundRole) {
+      if (!foundRole && !blocked.includes(githubID)) {
         log.debug(`Assigning contributor role to user ${m.name}`)
         const role = g.roles.find(r => r.name.toLowerCase() === roleName)
         m.addRole(role).catch(e => log.debug(e))


### PR DESCRIPTION
I had trouble setting up the `!ghauth` of a dummy user to test this adequately, but i tested everything BUT assigning discord roles on a private organization since i don't have enough permissions to access the api for blocked users of runelite.