### PR TITLE
Fix org blocking, prevent ghauth when blocked, remove github-verified

### DIFF
--- a/lib/blocked.js
+++ b/lib/blocked.js
@@ -41,14 +41,17 @@ function ensureBlockedFromOrganization (guilds, githubID) {
   guilds.forEach(g => {
     const m = g.members.get(authedDiscordUserId)
     if (m) {
-      const roleName = config.github.contributedRole.toLowerCase()
-      const foundRole = m.roles.find(r => r.name.toLowerCase() === roleName)
+      const rolesToRemove = [ config.github.authedRole, config.github.contributedRole ]
 
-      if (foundRole) {
-        log.debug(`Removing contributor role from blocked user ${m.name}`)
-        const role = g.roles.find(r => r.name.toLowerCase() === roleName)
-        m.removeRole(role).catch(e => log.debug(e))
-      }
+      rolesToRemove.forEach(n => {
+        const foundRole = m.roles.find(r => r.name.toLowerCase() === n.toLowerCase())
+
+        if (foundRole) {
+          log.debug(`Removing role '${n}' from blocked user ${m.name}`)
+          const role = g.roles.find(r => r.name.toLowerCase() === n)
+          m.removeRole(role).catch(e => log.debug(e))
+        }
+      })
     }
   })
 }

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -2,6 +2,7 @@ const fetch = require('node-fetch')
 const config = require('./config')
 const { log, createEmbed, sendStream, sendDM, githubUserDb } = require('./common')
 const { contributors } = require('./contributors')
+const { blocked } = require('./blocked')
 const { canExecuteCustomCommand, hasAdminPermissions, hasPermissions, noPermissions } = require('./security')
 
 const db = require('littledb')(config.databases.commands)
@@ -243,6 +244,18 @@ module.exports = (message, command, args) => {
               })
             }
 
+            // Save connection between GitHub user id and Discord user id
+            githubUserDb.put(body.id, message.author.id)
+
+            if (blocked[body.id]) {
+              return sendDM(message.author, {
+                embed: createEmbed()
+                  .setTitle('GitHub account linking')
+                  .setDescription('Your account has been banned from using this feature.')
+                  .setColor(0xFF0000)
+              })
+            }
+
             message.client.guilds.forEach(g => g
               .fetchMember(message.author)
               .then(m => {
@@ -257,9 +270,6 @@ module.exports = (message, command, args) => {
                 }
               })
               .catch(e => log.debug(e)))
-
-            // Save connection between GitHub user id and Discord user id
-            githubUserDb.put(body.id, message.author.id)
 
             return sendDM(message.author, {
               embed: createEmbed()

--- a/lib/contributors.js
+++ b/lib/contributors.js
@@ -43,7 +43,7 @@ function ensureContributorRole (guilds, githubID) {
       const roleName = config.github.contributedRole.toLowerCase()
       const foundRole = m.roles.find(r => r.name.toLowerCase() === roleName)
 
-      if (!foundRole && !blocked.includes(githubID)) {
+      if (!foundRole && !blocked[githubID]) {
         log.debug(`Assigning contributor role to user ${m.name}`)
         const role = g.roles.find(r => r.name.toLowerCase() === roleName)
         m.addRole(role).catch(e => log.warn(e))


### PR DESCRIPTION
Fixes organization block checking. The old code was using .includes which isn't correct.

Prevents using !ghauth to get roles if user is org blocked. Still saves the connection between their Discord account and their GitHub account.

Removes the authed role (github-verified) on block in addition to the pre-existing github-contributor role removal.
