### PR TITLE
Add check for existing guild when filtering messages

### DIFF
--- a/lib/security.js
+++ b/lib/security.js
@@ -75,7 +75,7 @@ function buildMessageDetail (message) {
 }
 
 function messageFilter (message, client) {
-  if (hasPermissions(message.member)) {
+  if (hasPermissions(message.member) || !message.guild) {
     return false
   }
 


### PR DESCRIPTION
There is no reason to filter messages outside of server, and the guild
value is required for bunch of checks in the method, so simply skip the
whole check.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>