### PR TITLE
Do not mention users again in mod/server log messages, fix ban checks

### DIFF
--- a/lib/security.js
+++ b/lib/security.js
@@ -56,7 +56,7 @@ function buildUserDetail (user) {
 function buildMessageDetail (message) {
   let messageDetail = ''
 
-  const messageContent = message.content
+  const messageContent = message.cleanContent
   if (messageContent) {
     messageDetail += `\n**Message:** ${messageContent}`
   }
@@ -131,37 +131,37 @@ function messageFilter (message, client) {
   const spamMatches = cachedMessages.filter((m) => m.sentTimestamp > (Date.now() - config.spam.maxInterval))
   const member = message.guild.members.get(message.author.id)
 
-  if (spamMatches.length > config.spam.kickThreshold) {
+  if (spamMatches.length >= config.spam.kickThreshold) {
     deleteMessages(spamMatches, client)
     member.kick()
     return `:foot: Kicked. Spammed ${spamMatches.length} messages in a row`
   }
 
-  if (spamMatches.length > config.spam.muteThreshold) {
+  if (spamMatches.length >= config.spam.muteThreshold) {
     deleteMessages(spamMatches, client)
     assignRole(member, message.guild.roles, config.roles.muted)
     return `:mute: Muted. Spammed ${spamMatches.length} messages in a row`
   }
 
-  if (spamMatches.length > config.spam.banThreshold) {
+  if (spamMatches.length >= config.spam.banThreshold) {
     deleteMessages(spamMatches, client)
     member.ban()
     return `:hammer: Banned. Spammed ${spamMatches.length} messages in a row`
   }
 
-  if (duplicateMatches.length > config.spam.maxDuplicatesKick) {
+  if (duplicateMatches.length >= config.spam.maxDuplicatesKick) {
     deleteMessages([...duplicateMatches, ...spamOtherDuplicates], client)
     member.kick()
     return `:foot: Kicked. Spammed ${duplicateMatches.length} same messages in a row`
   }
 
-  if (duplicateMatches.length > config.spam.maxDuplicatesMute) {
+  if (duplicateMatches.length >= config.spam.maxDuplicatesMute) {
     deleteMessages([...duplicateMatches, ...spamOtherDuplicates], client)
     assignRole(member, message.guild.roles, config.roles.muted)
     return `:mute: Muted. Spammed ${duplicateMatches.length} same messages in a row`
   }
 
-  if (duplicateMatches.length > config.spam.maxDuplicatesBan) {
+  if (duplicateMatches.length >= config.spam.maxDuplicatesBan) {
     deleteMessages([...duplicateMatches, ...spamOtherDuplicates], client)
     member.ban()
     return `:hammer: Banned. Spammed ${duplicateMatches.length} same messages in a row`


### PR DESCRIPTION
Instead of using message content directly, use cleaned up version that
is replacing mentions with text. Also fix checks for ban/kick threshold
to do gteeq instead of just gte.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>