### PR TITLE
Check if guild is present on messageDelete callback

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -146,7 +146,13 @@ client.on('guildMemberRemove', (member) => {
 
 client.on('messageDelete', (message) => {
   const user = message.author
-  const logs = message.guild.channels.find(c => c.name === config.channels.serverLogs)
+  const guild = message.guild
+
+  if (!guild) {
+    return
+  }
+
+  const logs = guild.channels.find(c => c.name === config.channels.serverLogs)
 
   if (!logs) {
     return


### PR DESCRIPTION
If guild is not present this is coming most likely from DMs and the
functionality is reliant on being in guild.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>