### PR TITLE
Remove restriction on multi-account linking

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -84,7 +84,7 @@ client.on('message', message => {
   const args = message.content.slice(config.prefix.length).trim().split(/ +/g)
   const command = args.shift().toLowerCase()
   log.debug('Received command', command, args)
-  commands(message, command, args)
+  commands(message, command, args).catch(log.debug)
 })
 
 client.on('presenceUpdate', (oldMember, newMember) => {

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -3,13 +3,13 @@ const config = require('./config')
 const { log, createEmbed, sendDM, githubUserDb, filteredWordsDb } = require('./common')
 const { sendStream } = require('./twitch')
 const { blocked } = require('./blocked')
-const { canExecuteCustomCommand, hasAdminPermissions, hasPermissions, noPermissions, assignRole } = require('./security')
+const { canExecuteCustomCommand, hasAdminPermissions, hasPermissions, noPermissions, assignRole, removeRole } = require('./security')
 
 const db = require('littledb')(config.databases.commands)
 
 let membersToProcess = []
 
-module.exports = (message, command, args) => {
+module.exports = async (message, command, args) => {
   const value = args.join(' ')
 
   switch (command) {
@@ -49,43 +49,37 @@ module.exports = (message, command, args) => {
       }
 
       if (hasPermissions(message.member)) {
-        message.channel.send(toSend)
+        return message.channel.send(toSend)
       } else {
-        sendDM(message.author, toSend).catch(() => noPermissions(message))
+        return sendDM(message.author, toSend).catch(() => noPermissions(message))
       }
-
-      break
     case 'gh':
-      fetch(`https://api.github.com/search/issues?q=repo:runelite/runelite+${value}`, {
+      const issueBody = await fetch(`https://api.github.com/search/issues?q=repo:runelite/runelite+${value}`, {
         headers: {
           Authorization: `token ${config.githubToken}`
         }
-      })
-        .then(res => res.json())
-        .then(body => {
-          const item = body.items[0]
-          let description = item.body.substring(0, 500)
+      }).then(res => res.json())
 
-          const lines = description.split('\n')
-          if (lines.length > 7) {
-            description = lines.splice(0, 7).join('\n')
-          }
+      const item = issueBody.items[0]
+      let description = item.body.substring(0, 500)
 
-          if (description !== item.body) {
-            description += '...'
-          }
+      const lines = description.split('\n')
+      if (lines.length > 7) {
+        description = lines.splice(0, 7).join('\n')
+      }
 
-          const embed = createEmbed()
-            .setTitle(`#${item.number} ${item.title}`)
-            .setAuthor(item.user.login)
-            .setURL(item.html_url)
-            .setDescription(description)
-            .setThumbnail(item.user.avatar_url)
+      if (description !== item.body) {
+        description += '...'
+      }
 
-          return message.channel.send({ embed })
-        }).catch(e => log.debug(e))
+      const embed = createEmbed()
+        .setTitle(`#${item.number} ${item.title}`)
+        .setAuthor(item.user.login)
+        .setURL(item.html_url)
+        .setDescription(description)
+        .setThumbnail(item.user.avatar_url)
 
-      break
+      return message.channel.send({ embed })
     case 'add':
       const subCommandVal = args.shift()
       if (!subCommandVal) {
@@ -103,14 +97,12 @@ module.exports = (message, command, args) => {
         return noPermissions(message)
       }
 
-      message.channel.send({
+      return message.channel.send({
         embed: createEmbed()
           .setTitle('Successfully added command')
           .addField(subCommand, db.put(subCommand, subValue))
           .setColor(0x00FF00)
       })
-
-      break
     case 'del':
       if (!value) {
         return
@@ -121,14 +113,12 @@ module.exports = (message, command, args) => {
       }
 
       db.put(value)
-      message.channel.send({
+      return message.channel.send({
         embed: createEmbed()
           .setTitle('Successfully deleted command')
           .setDescription(value)
           .setColor(0xFF0000)
       })
-
-      break
     case 'stream':
       if (!value) {
         return
@@ -138,8 +128,7 @@ module.exports = (message, command, args) => {
         return noPermissions(message)
       }
 
-      sendStream(message.channel, message.member, value)
-      break
+      return sendStream(message.channel, message.member, value)
     case 'procadd': {
       if (!value) {
         return
@@ -153,7 +142,7 @@ module.exports = (message, command, args) => {
       const array = members.array()
       membersToProcess = membersToProcess.concat(array)
 
-      message.channel.send({
+      return message.channel.send({
         embed: createEmbed()
           .setTitle('Added more people to processing list')
           .addField('regex', value)
@@ -161,8 +150,6 @@ module.exports = (message, command, args) => {
           .addField('total', membersToProcess.length)
           .setColor(0xFF0000)
       })
-
-      break
     }
     case 'procdel': {
       if (!hasAdminPermissions(message.member)) {
@@ -170,45 +157,43 @@ module.exports = (message, command, args) => {
       }
 
       membersToProcess = []
-      message.channel.send({
+      return message.channel.send({
         embed: createEmbed()
           .setTitle('Cleared processing list')
           .setColor(0xFF0000)
       })
-
-      break
     }
     case 'prockick': {
       if (!hasAdminPermissions(message.member) || membersToProcess.length >= 1000) {
         return noPermissions(message)
       }
 
-      message.channel.send({
+      await message.channel.send({
         embed: createEmbed()
           .setTitle('Kicking a lot of people!')
           .addField('matches', membersToProcess.length)
           .setColor(0xFF0000)
       })
 
-      membersToProcess.forEach(m => m.kick())
+      const toProcess = membersToProcess.map(m => m.kick())
       membersToProcess = []
-      break
+      return Promise.all(toProcess)
     }
     case 'procban': {
       if (!hasAdminPermissions(message.member) || membersToProcess.length >= 1000) {
         return noPermissions(message)
       }
 
-      message.channel.send({
+      await message.channel.send({
         embed: createEmbed()
           .setTitle('Banning a lot of people!')
           .addField('matches', membersToProcess.length)
           .setColor(0xFF0000)
       })
 
-      membersToProcess.forEach(m => m.ban())
+      const toProcess = membersToProcess.map(m => m.ban())
       membersToProcess = []
-      break
+      return Promise.all(toProcess)
     }
     case 'ghauth': {
       if (!value) {
@@ -229,7 +214,7 @@ module.exports = (message, command, args) => {
         })
       }
 
-      return fetch('https://github.com/login/oauth/access_token', {
+      const accessResponse = await fetch('https://github.com/login/oauth/access_token', {
         method: 'POST',
         body: JSON.stringify({
           client_id: config.github.clientId,
@@ -241,58 +226,79 @@ module.exports = (message, command, args) => {
           'Accept': 'application/json'
         }
       }).then(res => res.json())
-        .then(body => fetch('https://api.github.com/user', {
-          headers: {
-            'Authorization': 'token ' + body.access_token
-          }
-        }))
-        .then(res => res.json())
-        .then(body => {
-          if (body.id) {
-            const authedDiscordUserId = githubUserDb.get(body.id)
 
-            // Don't allow linking a GitHub account to many Discord accounts
-            if (authedDiscordUserId && authedDiscordUserId !== message.author.id) {
-              return sendDM(message.author, {
-                embed: createEmbed()
-                  .setTitle('GitHub account linking')
-                  .setDescription('Your GitHub account is already linked to a Discord user.')
-                  .setColor(0xFF0000)
-              })
-            }
+      const userResponse = await fetch('https://api.github.com/user', {
+        headers: {
+          'Authorization': 'token ' + accessResponse.access_token
+        }
+      }).then(res => res.json())
 
-            // Save connection between GitHub user id and Discord user id
-            githubUserDb.put(body.id, message.author.id)
+      if (userResponse.id) {
+        const authedDiscordUserId = githubUserDb.get(userResponse.id)
 
-            if (blocked[body.id]) {
-              return sendDM(message.author, {
-                embed: createEmbed()
-                  .setTitle('GitHub account linking')
-                  .setDescription('Your account has been banned from using this feature.')
-                  .setColor(0xFF0000)
-              })
-            }
-
-            message.client.guilds.forEach(g => g
-              .fetchMember(message.author)
-              .then(m => assignRole(m, g.roles, config.roles.verified))
-              .catch(e => log.debug(e)))
-
-            return sendDM(message.author, {
-              embed: createEmbed()
-                .setTitle('GitHub account linking')
-                .setDescription('You have successfully linked your GitHub account with the bot.')
-                .setColor(0x00FF00)
-            })
-          }
-
+        if (authedDiscordUserId && authedDiscordUserId === message.author.id) {
+          // Don't allow linking a GitHub account to same account twice (no point)
           return sendDM(message.author, {
             embed: createEmbed()
               .setTitle('GitHub account linking')
-              .setDescription('The supplied token expired.')
+              .setDescription('Your GitHub account is already linked to this Discord user.')
               .setColor(0xFF0000)
           })
+        }
+
+        // Save connection between GitHub user id and Discord user id
+        githubUserDb.put(userResponse.id, message.author.id)
+
+        if (blocked[userResponse.id]) {
+          return sendDM(message.author, {
+            embed: createEmbed()
+              .setTitle('GitHub account linking')
+              .setDescription('Your account has been banned from using this feature.')
+              .setColor(0xFF0000)
+          })
+        }
+
+        const embed = createEmbed()
+          .setTitle('GitHub account linking')
+          .setDescription('You have successfully linked your GitHub account with the bot.')
+          .setColor(0x00FF00)
+
+        if (authedDiscordUserId) {
+          let removedMember = null
+
+          await Promise.all(message.client.guilds.map(g => g
+            .fetchMember(authedDiscordUserId)
+            .then(m => {
+              if (!removedMember) {
+                removedMember = m
+              }
+
+              return m
+            })
+            .then(m => removeRole(m, g.roles, config.roles.verified))
+            .catch(e => log.debug(e))))
+
+          if (removedMember) {
+            embed.addField('Previous account unlinked', removedMember.user.username + '#' + removedMember.user.discriminator)
+          }
+        }
+
+        await Promise.all(message.client.guilds.map(g => g
+          .fetchMember(message.author)
+          .then(m => assignRole(m, g.roles, config.roles.verified))
+          .catch(e => log.debug(e))))
+
+        return sendDM(message.author, {
+          embed
         })
+      }
+
+      return sendDM(message.author, {
+        embed: createEmbed()
+          .setTitle('GitHub account linking')
+          .setDescription('The supplied token expired.')
+          .setColor(0xFF0000)
+      })
     }
     case 'ghwhois': {
       if (!value) {
@@ -314,61 +320,55 @@ module.exports = (message, command, args) => {
         }
 
         if (ghId) {
-          return fetch(`https://api.github.com/user/${ghId}`, {
+          const userResponse = await fetch(`https://api.github.com/user/${ghId}`, {
             headers: {
               Authorization: `token ${config.githubToken}`
             }
           }).then(res => res.json())
-            .then(body => {
-              let embed
 
-              if (body.id) {
-                embed = createEmbed()
-                  .setAuthor(body.name, body.avatar_url, body.html_url)
-                  .setThumbnail('')
-              } else {
-                embed = createEmbed()
-                  .setDescription(`${value} is not a registered GitHub user.`)
-              }
+          let embed
 
-              return message.channel.send({ embed })
-            })
-            .catch(e => log.debug(e))
+          if (userResponse.id) {
+            embed = createEmbed()
+              .setAuthor(userResponse.name, userResponse.avatar_url, userResponse.html_url)
+              .setThumbnail('')
+          } else {
+            embed = createEmbed()
+              .setDescription(`${value} is not a registered GitHub user.`)
+          }
+
+          return message.channel.send({ embed })
         }
       }
 
-      fetch(`https://api.github.com/users/${value}`, {
+      const userResponse = await fetch(`https://api.github.com/users/${value}`, {
         headers: {
           Authorization: `token ${config.githubToken}`
         }
       }).then(res => res.json())
-        .then(body => {
-          let embed
 
-          if (body.id) {
-            const discordId = githubUserDb.get(body.id)
+      let embed
 
-            if (discordId) {
-              const messMember = message.guild.members.get(discordId)
+      if (userResponse.id) {
+        const discordId = githubUserDb.get(userResponse.id)
 
-              if (messMember) {
-                embed = createEmbed()
-                  .setAuthor(messMember.user.username + '#' + messMember.user.discriminator, messMember.user.avatarURL)
-                  .setDescription(`<@${discordId}>`)
-                  .setThumbnail('')
-              }
-            } else {
-              embed = createEmbed().setDescription(`${value} has not connected their Discord account.`)
-            }
-          } else {
-            embed = createEmbed().setDescription(`${value} has not connected their Discord account.`)
+        if (discordId) {
+          const messMember = message.guild.members.get(discordId)
+
+          if (messMember) {
+            embed = createEmbed()
+              .setAuthor(messMember.user.username + '#' + messMember.user.discriminator, messMember.user.avatarURL)
+              .setDescription(`<@${discordId}>`)
+              .setThumbnail('')
           }
+        } else {
+          embed = createEmbed().setDescription(`${value} has not connected their Discord account.`)
+        }
+      } else {
+        embed = createEmbed().setDescription(`${value} has not connected their Discord account.`)
+      }
 
-          return message.channel.send({ embed })
-        })
-        .catch(e => log.debug(e))
-
-      break
+      return message.channel.send({ embed })
     }
     case 'filteradd': {
       if (!value) {
@@ -380,8 +380,7 @@ module.exports = (message, command, args) => {
       }
 
       filteredWordsDb.put(value, true)
-      message.channel.send(`Successfully added filtered word ${value}`)
-      break
+      return message.channel.send(`Successfully added filtered word ${value}`)
     }
     case 'filterdel': {
       if (!value) {
@@ -393,21 +392,19 @@ module.exports = (message, command, args) => {
       }
 
       filteredWordsDb.put(value)
-      message.channel.send(`Successfully removed filtered word ${value}`)
-      break
+      return message.channel.send(`Successfully removed filtered word ${value}`)
     }
     case 'filterls': {
       if (!hasPermissions(message.member)) {
         return noPermissions(message)
       }
 
-      message.channel.send({
+      return message.channel.send({
         embed: createEmbed()
           .setTitle('List of filtered words')
           .setDescription(filteredWordsDb.ls().join('\n'))
           .setColor(0x00FF00)
       })
-      break
     }
     default: {
       const value = db.get(command)
@@ -420,7 +417,7 @@ module.exports = (message, command, args) => {
         return sendDM(message.author, value).catch(() => noPermissions(message))
       }
 
-      message.channel.send(value)
+      return message.channel.send(value)
     }
   }
 }

--- a/lib/security.js
+++ b/lib/security.js
@@ -189,6 +189,19 @@ function assignRole (member, allRoles, roleToGive) {
   }
 }
 
+function removeRole (member, allRoles, roleToRemove) {
+  const roleName = roleToRemove.toLowerCase()
+  const foundRole = member.roles.find(r => r.name.toLowerCase() === roleName)
+
+  if (foundRole) {
+    const role = allRoles.find(r => r.name.toLowerCase() === roleName)
+    if (role) {
+      log.debug(`Removing '${roleToRemove}' role from user ${member.user.username}`)
+      return member.removeRole(role).catch(e => log.warn(e))
+    }
+  }
+}
+
 module.exports = {
   canExecuteCustomCommand,
   hasPermissions,
@@ -197,6 +210,7 @@ module.exports = {
   messageFilter,
   resetMessageCache,
   assignRole,
+  removeRole,
   buildUserDetail,
   buildMessageDetail
 }


### PR DESCRIPTION
Instead of preventing people to link gh account to different account
simply send message what acccount was unlinked, remove authed role from
old account and link new account.

Also switch command processing to use async/await

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>