### PR TITLE
Remove duplicate github account linking logic

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -241,7 +241,7 @@ module.exports = async (message, command, args) => {
 
       if (userResponse.id) {
         const authedDiscordUserId = githubUserDb.get(userResponse.id)
-        const discordMember = message.guild.members.get(message.author.id)
+        const discordMember = message.guild ? message.guild.members.get(message.author.id) : null
 
         if (
           authedDiscordUserId &&

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -247,7 +247,7 @@ module.exports = async (message, command, args) => {
           authedDiscordUserId &&
           authedDiscordUserId === message.author.id &&
           discordMember &&
-          discordMember.roles.find((role) => role.name === 'github-verified')
+          discordMember.roles.find((role) => role.name === config.roles.verified)
         ) {
           // Don't allow linking a GitHub account to same account twice if they already have
           // `github-verified` role (no point).

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -241,26 +241,6 @@ module.exports = async (message, command, args) => {
 
       if (userResponse.id) {
         const authedDiscordUserId = githubUserDb.get(userResponse.id)
-        const discordMember = message.guild ? message.guild.members.get(message.author.id) : null
-
-        if (
-          authedDiscordUserId &&
-          authedDiscordUserId === message.author.id &&
-          discordMember &&
-          discordMember.roles.find((role) => role.name === config.roles.verified)
-        ) {
-          // Don't allow linking a GitHub account to same account twice if they already have
-          // `github-verified` role (no point).
-          return sendDM(message.author, {
-            embed: createEmbed()
-              .setTitle('GitHub account linking')
-              .setDescription('Your GitHub account is already linked to this Discord user.')
-              .setColor(0xFF0000)
-          })
-        }
-
-        // Save connection between GitHub user id and Discord user id
-        githubUserDb.put(userResponse.id, message.author.id)
 
         if (blocked[userResponse.id]) {
           return sendDM(message.author, {
@@ -270,6 +250,9 @@ module.exports = async (message, command, args) => {
               .setColor(0xFF0000)
           })
         }
+
+        // Save connection between GitHub user id and Discord user id
+        githubUserDb.put(userResponse.id, message.author.id)
 
         const embed = createEmbed()
           .setTitle('GitHub account linking')

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -241,9 +241,16 @@ module.exports = async (message, command, args) => {
 
       if (userResponse.id) {
         const authedDiscordUserId = githubUserDb.get(userResponse.id)
+        const discordMember = message.guild.members.get(message.author.id)
 
-        if (authedDiscordUserId && authedDiscordUserId === message.author.id) {
-          // Don't allow linking a GitHub account to same account twice (no point)
+        if (
+          authedDiscordUserId &&
+          authedDiscordUserId === message.author.id &&
+          discordMember &&
+          discordMember.roles.find((role) => role.name === 'github-verified')
+        ) {
+          // Don't allow linking a GitHub account to same account twice if they already have
+          // `github-verified` role (no point).
           return sendDM(message.author, {
             embed: createEmbed()
               .setTitle('GitHub account linking')


### PR DESCRIPTION
Resolves #47 

We should early exit only if the user already has the `github-verified` role.