### PR TITLE
Make Twitch announcements more stable

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -1,7 +1,7 @@
 const fetch = require('node-fetch')
 const Discord = require('discord.js')
 const { log, sendDM } = require('./common')
-const { updateStream } = require('./twitch')
+const { updateStream, updateStreams } = require('./twitch')
 const { fetchContributors } = require('./contributors')
 const { fetchBlocked } = require('./blocked')
 const { messageFilter, resetMessageCache, buildUserDetail, buildMessageDetail } = require('./security')
@@ -52,6 +52,7 @@ client.on('ready', () => {
   scheduleWithFixedDelay(client, () => fetchAllContributors(client), 30 * 60000)
   scheduleWithFixedDelay(client, () => fetchBlocked(client.guilds), 60 * 60000)
   scheduleWithFixedDelay(client, () => resetMessageCache(), 60 * 60000)
+  scheduleWithFixedDelay(client, () => updateStreams(client), 5 * 60000)
 })
 
 client.on('message', message => {
@@ -95,10 +96,8 @@ client.on('presenceUpdate', (oldMember, newMember) => {
 
   const oldUrl = oldMember.presence && oldMember.presence.game && oldMember.presence.game.streaming && oldMember.presence.game.url
   const newUrl = newMember.presence && newMember.presence.game && newMember.presence.game.streaming && newMember.presence.game.url
-  const streamerUrl = newUrl || oldUrl || ''
-  const streamerId = streamerUrl.replace('https://www.twitch.tv/', '')
 
-  updateStream(newMember, streamerId, newUrl).catch(log.debug)
+  updateStream(newMember, oldUrl, newUrl).catch(log.debug)
 })
 
 client.on('guildBanAdd', (guild, user) => {

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -134,7 +134,10 @@ module.exports = async (message, command, args) => {
         return noPermissions(message)
       }
 
-      return sendStream(message.channel, message.member, value)
+      return sendStream(message.channel, {
+        'name': message.member.displayName,
+        'avatar': message.member.displayAvatarURL
+      }, value)
     case 'procadd': {
       if (!value) {
         return

--- a/lib/twitch.js
+++ b/lib/twitch.js
@@ -1,8 +1,16 @@
 const fetch = require('node-fetch')
 const config = require('./config')
-const { createEmbed } = require('./common')
+const { createEmbed, log } = require('./common')
 
-const streamerMessages = new Map()
+const streamingUsers = new Map()
+
+function parseStreamerId (url) {
+  if (!url) {
+    return ''
+  }
+
+  return url.replace(/https?:\/\/.*twitch.tv\//, '').trim()
+}
 
 async function sendStream (channel, member, streamerId) {
   const token = await fetch(`https://id.twitch.tv/oauth2/token?client_id=${config.twitchClientId}&client_secret=${config.twitchClientSecret}&grant_type=client_credentials`, {
@@ -19,13 +27,22 @@ async function sendStream (channel, member, streamerId) {
   const users = await fetch(`https://api.twitch.tv/helix/users?login=${streamerId}`, headers).then(res => res.json())
   const user = users.data[0]
 
+  if (!user) {
+    return Promise.resolve(new Error(`Invalid game or stream for user name: ${streamerId}`))
+  }
+
   const streams = await fetch(`https://api.twitch.tv/helix/streams?user_id=${user.id}`, headers).then(res => res.json())
   const stream = streams.data[0]
+
+  if (!stream) {
+    return Promise.resolve(new Error(`Invalid game or stream for user: ${streamerId}`))
+  }
+
   const games = await fetch(`https://api.twitch.tv/helix/games?id=${stream.game_id}`, headers).then(res => res.json())
   const game = games.data[0]
 
-  if (game.name.toLowerCase().indexOf('runescape') === -1) {
-    return Promise.reject(new Error(`Invalid game or stream: ${game.name}`))
+  if (!game || game.name.toLowerCase().indexOf('runescape') === -1) {
+    return Promise.resolve(new Error(`Invalid game or stream: ${game.name}`))
   }
 
   const image = stream.thumbnail_url
@@ -36,50 +53,75 @@ async function sendStream (channel, member, streamerId) {
 
   const embed = createEmbed()
     .setColor(6570406)
-    .setAuthor(member.displayName, member.user.displayAvatarURL, channelUrl)
+    .setAuthor(member.name || user.display_name, member.avatar || user.profile_image_url, channelUrl)
     .setDescription(user.description)
     .setThumbnail(user.profile_image_url)
     .setTitle(`${stream.title}`)
     .setURL(channelUrl)
     .setImage(image)
 
+  log.debug(`Sending stream for streamer ${streamerId}`)
   return channel.send({ embed })
 }
 
-async function updateStream (member, streamerId, url) {
-  if (!streamerId || streamerId.trim().length === 0) {
+function updateStream (member, oldUrl, newUrl) {
+  const streamerUrl = newUrl || oldUrl || ''
+  const streamerId = parseStreamerId(streamerUrl)
+
+  if (!streamerId || streamerId.length === 0) {
     return
   }
 
-  const message = streamerMessages.get(streamerId)
-
-  if (message || !url) {
-    if (message && !url) {
-      message.delete()
-      streamerMessages.delete(streamerId)
-    }
-
-    return
+  if (newUrl) {
+    streamingUsers.set(streamerId, {
+      'name': member.displayName,
+      'avatar': member.user.displayAvatarURL
+    })
+  } else {
+    streamingUsers.delete(streamerId)
   }
+}
 
-  const channel = member.client.channels.find(c => c.name === config.channels.streams)
+async function updateStreams (client) {
+  log.debug('Updating streams...')
+  const channel = client.channels.find(c => c.name === config.channels.streams)
 
   if (!channel) {
     return
   }
 
-  const m = await sendStream(channel, member, streamerId)
+  const messagesRaw = await channel.fetchMessages()
+  const filteredMessages = messagesRaw.filter(m => m.author.bot && m.author.id === client.user.id)
 
-  // Prevent sync issues
-  const oldMessage = streamerMessages.get(streamerId)
-  if (oldMessage) {
-    oldMessage.delete()
-  }
+  const activeMessages = await Promise.all(filteredMessages.map(m => {
+    const streamerId = parseStreamerId(m.embeds[0].url)
 
-  streamerMessages.set(streamerId, m)
+    if (!streamerId || streamerId.length === 0) {
+      return Promise.resolve(null)
+    }
+
+    if (!streamingUsers.has(streamerId)) {
+      return m.delete().then(() => null)
+    }
+
+    return Promise.resolve(streamerId)
+  }))
+
+  const messages = activeMessages.filter(m => m != null)
+
+  return Promise.all(Array.from(streamingUsers.keys()).map(k => {
+    const v = streamingUsers.get(k)
+
+    if (messages.indexOf(k) === -1) {
+      return sendStream(channel, v, k)
+    }
+
+    return Promise.resolve()
+  })).catch(log.debug)
 }
 
 module.exports = {
   sendStream,
-  updateStream
+  updateStream,
+  updateStreams
 }


### PR DESCRIPTION
Instead of checking Twitch API right away when someone starts streaming
populate map of streaming users and then periodically update streaming
messages based on contents of this map.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>