### PR TITLE
Fix checking for file extensions

### DIFF
--- a/lib/security.js
+++ b/lib/security.js
@@ -7,18 +7,18 @@ let messageCache = []
 
 const allowedExtensions = [
   // Text
-  'txt',
-  'log',
+  '.txt',
+  '.log',
   // Audio
-  'aif',
-  'cda',
-  'mid',
-  'midi',
-  'mp3',
-  'mpa',
-  'ogg',
-  'wav',
-  'wma'
+  '.aif',
+  '.cda',
+  '.mid',
+  '.midi',
+  '.mp3',
+  '.mpa',
+  '.ogg',
+  '.wav',
+  '.wma'
 ]
 
 function canExecuteCustomCommand (message) {


### PR DESCRIPTION
The path.extname is returning file extension together with dot

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>