### PR TITLE
Fix sorting when matching commands

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -453,7 +453,7 @@ module.exports = async (message, command, args) => {
         return sendDM(message.author, value).catch(() => noPermissions(message))
       }
 
-      const keys = commandsDb.ls().sort((a, b) => a.length - b.length).sort()
+      const keys = commandsDb.ls().sort().sort((a, b) => a.length - b.length)
 
       for (const key of keys) {
         if (key.toLowerCase().indexOf(command.toLowerCase()) !== -1) {


### PR DESCRIPTION
Command list needs to be sorted alphabetically first and then by length

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>