### PR TITLE
Fix !phwhois error messages

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -191,9 +191,11 @@ module.exports = async (message, command, args) => {
         }
       }).then(res => res.json()).catch(log.debug)
 
-      let response = `${value} is not a registered GitHub user.`
+      let response = `${user} is not a registered GitHub user.`
 
       if (userResponse.id) {
+        response = `${user} has not connected their Discord account.`
+
         const discordId = githubUserDb.get(userResponse.id)
 
         if (discordId) {
@@ -202,9 +204,9 @@ module.exports = async (message, command, args) => {
           if (messMember) {
             response = buildUserDetail(messMember.user)
           }
+        } else {
+          response = `[ ${userResponse.html_url} ] **${userResponse.login}**`
         }
-      } else {
-        response = `[ ${userResponse.html_url} ] **${userResponse.login}**`
       }
 
       return message.channel.send(response, { allowedMentions: { users: [] } })


### PR DESCRIPTION
In the code handling the Discord lookup here: https://github.com/runelite/runelite-discord-bot/blob/57c1912c4d3ebdd6ddf5735f1fc310060e16c566/lib/commands.js#L194-L210

The default response is incorrectly formatted to begin with. If a user "bobby" has a plugin "example-plugin", but has no associated Discord account, the message will read `example-plugin is not a registered GitHub user.`, rather than specifying that `bobby` is the one who isn't a GitHub user.

Additionally, this message is not updated if their GitHub user is found, but no connected Discord account is found. In the example above, the message should actually say `bobby has not connected their Discord account.`

This PR addresses both of these issues.