### PR TITLE
Allow helpers to setup notices

### DIFF
--- a/lib/commands/notice.js
+++ b/lib/commands/notice.js
@@ -67,7 +67,7 @@ export default {
         .setDescription('New timestamp value (empty to disable)')
         .setRequired(false))
     ),
-  permissions: ['moderator'],
+  permissions: ['moderator', 'helper'],
   async execute (interaction) {
     switch (interaction.options.getSubcommand()) {
       case 'show':


### PR DESCRIPTION
Allow helpers to use the `/notice` command.