### PR TITLE
autologs: add command

### DIFF
--- a/lib/commands/autologs.js
+++ b/lib/commands/autologs.js
@@ -1,0 +1,32 @@
+import { SlashCommandBuilder } from '@discordjs/builders'
+import config from '../config.js'
+
+export default {
+  data: new SlashCommandBuilder()
+    .setName('autologs')
+    .setDescription('Instructions for automatically collecting logs'),
+  async execute (interaction) {
+    const logChannel = interaction.guild.channels.cache.find(c => c.name === config.channels.autoLogs)
+    if (!logChannel) {
+      return
+    }
+
+    const message = [
+      'To automatically upload your log files to this server, use the following instructions:',
+      '',
+      '**Windows:**',
+      '  1. Press Windows+X and select "Windows PowerShell"',
+      '  2. Copy the entire section below into the window and use **right-click** to paste the contents into the PowerShell window:',
+      '```ps1',
+      `$(Invoke-WebRequest -Uri "${config.autoLogs.logScriptUrlWindows}" -UseBasicParsing).Content | powershell.exe`,
+      '```',
+      '**macOS + Linux:**',
+      '  1. Press ⌘+Space to open the launcher, type "Terminal" and open "Terminal.app"',
+      '  2. Copy the entire section below into the window and use **⌘+V** to paste the contents into the Terminal window:',
+      '```sh',
+      `curl ${config.autoLogs.logScriptUrlMacOS} | bash`,
+      '```'
+    ].join('\n')
+    await interaction.followUp(message)
+  }
+}

--- a/lib/config.js
+++ b/lib/config.js
@@ -51,6 +51,8 @@ export default {
     serverLogs: 'server-logs',
     // Name of Discord channel where bot DMs will be forwarded
     modMail: 'mod-mail',
+    // Name of Discord channel where /autologs webhooks will be installed
+    autoLogs: 'support-logs',
     // Support channel used for mod mail warning
     support: 'support',
     // Name of channels where notices will be posted
@@ -137,5 +139,9 @@ export default {
       '.wma',
       '.mkv'
     ]
+  },
+  autoLogs: {
+    logScriptUrlWindows: process.env.AUTOLOGS_SCRIPT_URL_WIN || 'https://static.runelite.net/autologs.ps1',
+    logScriptUrlMacOS: process.env.AUTOLOGS_SCRIPT_URL_MAC || 'https://static.runelite.net/autologs.sh'
   }
 }


### PR DESCRIPTION
As a convenience to users receiving support in the Discord server, this provides an automatic method of obtaining logs from the default location (~/.runelite/logs) with a PowerShell script on Windows, then POSTing the files to a Discord webhook in the server to receive them.

Users wary of pipe-shell commands can continue to use manual log uploading as described in the `/logs` command.

The scripts will need to be hosted at a known location and the URL provided in the config:

<details>
<summary>Windows</summary>

```ps1

$CLIENT_PATH="$env:USERPROFILE/.runelite/logs/client.log"
$LAUNCHER_PATH="$env:USERPROFILE/.runelite/logs/launcher.log"
if (-not(Test-Path -Path "$CLIENT_PATH" -PathType Leaf)) {
	Write-Host "client.log not found."
	exit -1
}

if (-not(Test-Path -Path "$LAUNCHER_PATH" -PathType Leaf)) {
	Write-Host "launcher.log not found"
	exit -1
}

$FORM_BOUNDARY = [System.Guid]::NewGuid().ToString();
$LF = "`r`n"

$CLIENT_B = [System.IO.File]::ReadAllBytes($CLIENT_PATH)
$CLIENT_S = [System.Text.Encoding]::GetEncoding("UTF-8").GetString($CLIENT_B)
$LAUNCHER_B = [System.IO.File]::ReadAllBytes($LAUNCHER_PATH)
$LAUNCHER_S = [System.Text.Encoding]::GetEncoding("UTF-8").GetString($LAUNCHER_B)

$BODY = (
	"--$FORM_BOUNDARY",
	"Content-Disposition: form-data; name=`"file[0]`"; filename=`"client.log`"",
	"Content-Type: application/octet-stream$LF",
	$CLIENT_S,
	"--$FORM_BOUNDARY",
	"Content-Disposition: form-data; name=`"file[1]`"; filename=`"launcher.log`"",
	"Content-Type: application/octet-stream$LF",
	$LAUNCHER_S,
	"--$FORM_BOUNDARY--$LF"
) -join $LF
Write-Host "$BODY"

$WEBHOOK = "https://api.runelite.net/autologs"
Invoke-RestMethod -Uri $WEBHOOK -Method Post -ContentType "multipart/form-data; boundary=`"$FORM_BOUNDARY`"" -Body $BODY
```
</details>

<details>
<summary>macOS</summary>

```sh
#!/bin/bash

CLIENT_PATH="$HOME/.runelite/logs/client.log"
LAUNCHER_PATH="$HOME/.runelite/logs/launcher.log"

if [[ ! -f $CLIENT_PATH ]]; then
    echo "client.log not found."
    exit -1
fi

if [[ ! -f $LAUNCHER_PATH ]]; then
    echo "launcher.log not found."
    exit -1
fi

curl -F "file[0]=@$CLIENT_PATH" -F "file[1]=@$LAUNCHER_PATH" https://api.runelite.net/autologs
```
</details>