### PR TITLE
Improve unmute message emoji

### DIFF
--- a/lib/commands/mutemenu.js
+++ b/lib/commands/mutemenu.js
@@ -28,7 +28,7 @@ export default {
       }
 
       if (logs) {
-        await logs.send(`:mute: ${buildUserDetail(user)} was unmuted by **${interaction.user.tag}**.`)
+        await logs.send(`:sound: ${buildUserDetail(user)} was unmuted by **${interaction.user.tag}**.`)
       }
 
       return interaction.followUp(`${buildUserDetail(user)} was unmuted.`)


### PR DESCRIPTION
It's weird for the bot to send a log message with the :mute: icon when a user is unmuted.