### PR TITLE
Permit .mp4 file attachments

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -143,6 +143,7 @@ export default {
       '.wav',
       '.wma',
       '.mkv',
+      '.mp4',
       '.rlp'
     ]
   },


### PR DESCRIPTION
In case we decide to whitelist ``.mp4`` file attachments for ``#support``. If e.g. ``.avi`` or ``.webm`` should also be whitelisted, feel free to amend or let me know.