### PR TITLE
fix typo in timeout logs

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -483,8 +483,8 @@ client.on('guildMemberUpdate', async (oldMember, newMember) => {
     }
 
     const timeoutMessage = newMember.communicationDisabledUntil
-      ? `was timeouted until **<t:${Math.floor(newMember.communicationDisabledUntil.getTime() / 1000)}>**`
-      : 'is no longer timeouted'
+      ? `was timed out until **<t:${Math.floor(newMember.communicationDisabledUntil.getTime() / 1000)}>**`
+      : 'is no longer timed out'
 
     const executorMessage = auditEntry && auditEntry.executor.tag
       ? ` by **${auditEntry.executor.tag}**`


### PR DESCRIPTION
timeouted isn't actually a word, since this beautiful English language is just made up wherever they felt like that day