### PR TITLE
Fix bug with spaces in hubsupport search

### DIFF
--- a/lib/commands/hubsupport.js
+++ b/lib/commands/hubsupport.js
@@ -35,12 +35,13 @@ export default {
     ),
   async execute (interaction) {
     let value = interaction.options.getString('name')
-    // Replace spaces with dashes to fix an issue with spaces not returning anything
-    value = value.replace(/\s+/g, '-')
 
     if (!value) {
       return interaction.followUp('Support for hub plugins should be directed to the author of the plugin.\nYou can find the support link by searching for the plugin in the Plugin Hub panel and clicking the `?` button on the plugin, or by right-clicking the plugin in the plugin panel and clicking the `Support` menu option.')
     }
+
+    // Replace spaces with dashes to fix an issue with spaces not returning anything
+    value = value.replace(/\s+/g, '-')
 
     const manifest = await fetchManifest()
     const plugin = manifest.display.find(p => p.internalName === value)

--- a/lib/commands/hubsupport.js
+++ b/lib/commands/hubsupport.js
@@ -34,7 +34,9 @@ export default {
       .setAutocomplete(true)
     ),
   async execute (interaction) {
-    const value = interaction.options.getString('name')
+    let value = interaction.options.getString('name')
+    // Replace spaces with dashes to fix an issue with spaces not returning anything
+    value = value.replace(/\s+/g, '-')
 
     if (!value) {
       return interaction.followUp('Support for hub plugins should be directed to the author of the plugin.\nYou can find the support link by searching for the plugin in the Plugin Hub panel and clicking the `?` button on the plugin, or by right-clicking the plugin in the plugin panel and clicking the `Support` menu option.')


### PR DESCRIPTION
Fixes #110 

Replacing spaces with dashes fixes #110 as the `internalName` from `https://repo.runelite.net/plugins/manifest/${version}_full.js` seems to return spaces as dashes. 

Example test.

Input = `plank sack`

Pre fix: 

![image](https://github.com/runelite/runelite-discord-bot/assets/38963376/ad840cd1-3f8a-4b73-b694-366c5fb166a9)

Post fix:
![image](https://github.com/runelite/runelite-discord-bot/assets/38963376/12600680-3b78-4489-8edb-7035327d7e5b)
